### PR TITLE
Update dependencies, set MSRV

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,15 +2,16 @@
 name = "tket-json-rs"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.60"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-uuid = { version = "0.8", features = ["serde"] }
-pyo3 = { version = "0.16.5", optional = true }
-pythonize ={version = "0.16.0", optional = true}
+uuid = { version = "1.4", features = ["serde"] }
+pyo3 = { version = "0.19.0", optional = true }
+pythonize ={version = "0.19.0", optional = true}
 
 
 [features]


### PR DESCRIPTION
Found the MSRV with `cargo-msrv`. 1.59 fails because of the `dep:` prefixes in `Cargo.toml`