### PR TITLE
doc: Add missing docs everywhere

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,5 +25,4 @@ pythonize = { version = "0.19.0", optional = true }
 
 
 [features]
-pyo3 = ["dep:pyo3", "dep:pythonize", "tket2ops"]
-tket2ops = []
+pyo3 = ["dep:pyo3", "dep:pythonize"]

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ Serializable Rust definition for circuits and operations of the
 ## Features
 
 -   `pyo3`: Enable Python bindings via pyo3.
--   `tket2ops`: Enable definitions for TKET2 operations.
 
 ## Recent Changes
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ tket-json-rs
 [![msrv][]](https://github.com/CQCL/tket-json-rs)
 [![docs][]](https://docs.rs/tket-json-rs)
 
-Serializable definition of TKET circuits and operations.
+Serializable Rust definition for circuits and operations of the
+[TKET](https://github.com/CQCL/tket) quantum compiler.
 
 ## Features
 
@@ -27,4 +28,4 @@ This project is licensed under Apache License, Version 2.0 ([LICENSE][] or http:
   [crates]: https://img.shields.io/crates/v/tket-json-rs
   [LICENSE]: LICENCE
   [msrv]: https://img.shields.io/badge/rust-1.60.0%2B-blue.svg?maxAge=3600
-  [RELEASES]: RELEASES.rst
+  [RELEASES]: RELEASES.md

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,5 @@
 # Release notes
 
-## [unreleased]
+## v0.1.0 (2023-08-18)
+
+-   Initial release.

--- a/src/circuit_json.rs
+++ b/src/circuit_json.rs
@@ -1,9 +1,14 @@
+//! Contains structs for serializing and deserializing TKET circuits to and from
+//! JSON.
+
 use crate::optype::OpType;
 use serde::{Deserialize, Serialize};
 
+/// A register of locations sharing the same name.
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Register(pub String, pub Vec<i64>);
 
+/// A gate defined by a circuit.
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq)]
 pub struct CompositeGate {
     // List of Symbols
@@ -12,33 +17,43 @@ pub struct CompositeGate {
     name: String,
 }
 
+/// A classical bit register.
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct BitRegister {
     name: String,
     size: u32,
 }
 
+/// The units used in a [`ClassicalExp`].
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq, Hash)]
 #[serde(untagged)]
 pub enum ClassicalExpUnit {
+    /// Unsigned 32-bit integer.
     U32(u32),
+    /// Register of locations.
     Register(Register),
+    /// Register of bits.
     BitRegister(BitRegister),
+    /// A nested classical expression.
     ClassicalExpUnit(ClassicalExp),
 }
 
+/// A box for holding classical expressions on Bits.
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct ClassicalExp {
     args: Vec<ClassicalExpUnit>,
     op: String,
 }
 
+/// A simple struct for Pauli strings with +/- phase, used to represent Pauli
+/// strings in a stabiliser subgroup.
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct PauliStabiliser {
     coeff: bool,
     string: Vec<String>,
 }
 
+/// Unique identifier for an [`OpBox`].
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct BoxID(uuid::Uuid);
 
@@ -47,41 +62,57 @@ pub struct BoxID(uuid::Uuid);
 /// to the operation is differently named when serializing.
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq)]
 #[serde(tag = "type")]
+#[allow(missing_docs)]
+#[non_exhaustive]
 pub enum OpBox {
+    /// Operation defined as a circuit.
     CircBox {
         id: BoxID,
+        /// The circuit defining the operation.
         circuit: SerialCircuit,
     },
+    /// One-qubit operation defined as a unitary matrix.
     Unitary1qBox {
         id: BoxID,
-        // 2x2 matrix of complex numbers
+        /// 2x2 matrix of complex numbers
         matrix: [[(f32, f32); 2]; 2],
     },
+    /// Two-qubit operation defined as a unitary matrix.
     Unitary2qBox {
         id: BoxID,
-        // 4x4 matrix of complex numbers
+        /// 4x4 matrix of complex numbers
         matrix: [[(f32, f32); 4]; 4],
     },
+    /// Three-qubit operation defined as a unitary matrix.
     Unitary3qBox {
         id: BoxID,
-        // 8x8 matric of complex numbers
+        /// 8x8 matric of complex numbers
         matrix: Box<[[(f32, f32); 8]; 8]>,
     },
+    /// Two-qubit operation defined in terms of a hermitian matrix and a phase.
     ExpBox {
         id: BoxID,
-        // 4x4 matrix of complex numbers
+        /// 4x4 matrix of complex numbers
         matrix: [[(f32, f32); 4]; 4],
+        /// Phase of the operation.
         phase: f64,
     },
+    /// Operation defined as the exponential of a tensor of Pauli operators.
     PauliExpBox {
         id: BoxID,
+        /// List of Pauli operators.
         paulis: Vec<String>,
-        // Symengine Expr
+        /// Symengine expression
         phase: String,
     },
+    /// An operation capable of representing arbitrary Circuits made up of CNOT
+    /// and RZ, as a PhasePolynomial plus a boolean matrix representing an
+    /// additional linear transformation.
     PhasePolyBox {
         id: BoxID,
+        /// Number of qubits.
         n_qubits: u32,
+        ///
         qubit_indices: Vec<(u32, u32)>,
     },
     StabiliserAssertionBox {
@@ -98,11 +129,15 @@ pub enum OpBox {
         // Vec of Symengine Expr
         params: Vec<String>,
     },
+    /// Wraps another quantum op, adding control qubits.
     QControlBox {
         id: BoxID,
+        /// Number of control qubits.
         n_controls: u32,
+        /// The operation to be controlled.
         op: Box<Operation>,
     },
+    /// Holding box for abstract expressions on Bits.
     ClassicalExpBox {
         id: BoxID,
         n_i: u32,
@@ -112,6 +147,7 @@ pub enum OpBox {
     },
 }
 
+/// Decorates another op, adding a QASM-style classical condition.
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq)]
 pub struct Conditional {
     op: Box<Operation>,
@@ -119,48 +155,69 @@ pub struct Conditional {
     value: u32,
 }
 
+/// Serializable operation descriptor.
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq)]
 pub struct Operation<P = String> {
+    /// The type of operation.
     #[serde(rename = "type")]
     pub op_type: OpType,
+    /// Number of input and output qubits.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub n_qb: Option<u32>,
+    /// Expressions for the parameters of the operation.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub params: Option<Vec<P>>,
+    /// Internal box for the operation.
     #[serde(rename = "box")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub op_box: Option<OpBox>,
+    /// The pre-computed signature.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub signature: Option<Vec<String>>,
+    /// A QASM-style classical condition for the operation.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub conditional: Option<Conditional>,
 }
 
+/// Operation applied in a circuit, with defined arguments.
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq)]
 pub struct Command<P = String> {
+    /// The operation to be applied.
     pub op: Operation<P>,
+    /// The arguments to the operation.
     pub args: Vec<Register>,
+    /// Operation group identifier.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub opgroup: Option<String>,
 }
 
+/// A permutation of the elements of a register.
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Permutation(pub Register, pub Register);
 
-/// Pytket canonical circuit
+/// Pytket canonical serialized circuit
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq)]
 pub struct SerialCircuit<P = String> {
+    /// The name of the circuit.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
-    // Symengine Expr
+    /// The global phase, as a symengine expression.
     pub phase: P,
+    /// List of commands in the circuit.
     pub commands: Vec<Command<P>>,
+    /// Input qubit registers.
     pub qubits: Vec<Register>,
+    /// Input bit registers.
     pub bits: Vec<Register>,
+    /// Implicit permutation of the output qubits.
     pub implicit_permutation: Vec<Permutation>,
 }
 
 impl<P> Operation<P> {
+    /// Returns a default-initialized Operation with the given type.
+    ///
+    /// For optypes that require additional parameters, this may generate
+    /// invalid operations.
     pub fn from_optype(op_type: OpType) -> Self {
         Self {
             op_type,

--- a/src/circuit_json.rs
+++ b/src/circuit_json.rs
@@ -86,7 +86,7 @@ pub enum OpBox {
     /// Three-qubit operation defined as a unitary matrix.
     Unitary3qBox {
         id: BoxID,
-        /// 8x8 matric of complex numbers
+        /// 8x8 matrix of complex numbers
         matrix: Box<[[(f32, f32); 8]; 8]>,
     },
     /// Two-qubit operation defined in terms of a hermitian matrix and a phase.
@@ -112,7 +112,6 @@ pub enum OpBox {
         id: BoxID,
         /// Number of qubits.
         n_qubits: u32,
-        ///
         qubit_indices: Vec<(u32, u32)>,
     },
     StabiliserAssertionBox {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,7 @@
+#![warn(missing_docs)]
+//! Serializable Rust definition for circuits and operations of the
+//! [TKET](https://github.com/CQCL/tket) quantum compiler.
+
 pub mod circuit_json;
 pub mod optype;
 #[cfg(feature = "pyo3")]
@@ -9,7 +13,6 @@ mod tests {
     use serde_json::to_string;
     #[test]
     fn read_json() {
-        // let expr = symengine::Expression::new("a + b + 3");
         let circ_s = r#"{"bits": [["c", [0]], ["c", [1]]], "commands": [{"args": [["q", [0]]], "op": {"type": "H"}}, {"args": [["q", [0]], ["q", [1]]], "op": {"type": "CX"}}, {"args": [["q", [0]], ["c", [0]]], "op": {"type": "Measure"}}, {"args": [["q", [1]], ["c", [1]]], "op": {"type": "Measure"}}], "implicit_permutation": [[["q", [0]], ["q", [0]]], [["q", [1]], ["q", [1]]]], "phase": "0.0", "qubits": [["q", [0]], ["q", [1]]]}"#;
         let ser: SerialCircuit = serde_json::from_str(circ_s).unwrap();
 

--- a/src/optype.rs
+++ b/src/optype.rs
@@ -1,594 +1,432 @@
+//! Defines the `OpType` enum, which represents the operation types in a quantum
+//! circuit.
+
 #[cfg(feature = "pyo3")]
 use pyo3::prelude::*;
 #[cfg(feature = "pyo3")]
 use pyo3::{exceptions::PyNotImplementedError, pyclass::CompareOp};
 use serde::{Deserialize, Serialize};
 
+/// Operation types in a quantum circuit.
 #[cfg_attr(feature = "pyo3", pyclass(name = "RsOpType"))]
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum OpType {
-    /**
-     * Quantum input node of the circuit
-     */
+    /// Quantum input node of the circuit
     Input,
 
-    /**
-     * Quantum output node of the circuit
-     */
+    /// Quantum output node of the circuit
     Output,
 
-    /**
-     * Quantum node with no predecessors, implicitly in zero state.
-     */
+    /// Quantum node with no predecessors, implicitly in zero state.
     Create,
 
-    /**
-     * Quantum node with no successors, not composable with input nodes of other
-     * circuits.
-     */
+    /// Quantum node with no successors, not composable with input nodes of other
+    /// circuits.
     Discard,
 
-    /**
-     * Classical input node of the circuit
-     */
+    /// Classical input node of the circuit
     ClInput,
 
-    /**
-     * Classical output node of the circuit
-     */
+    /// Classical output node of the circuit
     ClOutput,
 
-    /**
-     * No-op that must be preserved by compilation
-     */
+    /// No-op that must be preserved by compilation
     Barrier,
 
-    /**
-     * FlowOp introducing a target for Branch or Goto commands
-     */
+    /// FlowOp introducing a target for Branch or Goto commands
     Label,
 
-    /**
-     * Execution jumps to a label if a condition bit is true (1),
-     * otherwise continues to next command
-     */
+    /// Execution jumps to a label if a condition bit is true (1),
+    /// otherwise continues to next command
     Branch,
 
-    /**
-     * Execution jumps to a label unconditionally
-     */
+    /// Execution jumps to a label unconditionally
     Goto,
 
-    /**
-     * Execution halts and the program terminates
-     */
+    /// Execution halts and the program terminates
     Stop,
 
-    /**
-     * A general classical operation where all inputs are also outputs
-     */
+    /// A general classical operation where all inputs are also outputs
     ClassicalTransform,
 
-    /**
-     * An operation to set some bits to specified values
-     */
+    /// An operation to set some bits to specified values
     SetBits,
 
-    /**
-     * An operation to copy some bit values
-     */
+    /// An operation to copy some bit values
     CopyBits,
 
-    /**
-     * A classical predicate defined by a range of values in binary encoding
-     */
+    /// A classical predicate defined by a range of values in binary encoding
     RangePredicate,
 
-    /**
-     * A classical predicate defined by a truth table
-     */
+    /// A classical predicate defined by a truth table
     ExplicitPredicate,
 
-    /**
-     * An operation defined by a truth table that modifies one bit
-     */
+    /// An operation defined by a truth table that modifies one bit
     ExplicitModifier,
 
-    /**
-     * A classical operation applied to multiple bits simultaneously
-     */
+    /// A classical operation applied to multiple bits simultaneously
     MultiBit,
 
-    /**
-     * \f$ \left[ \begin{array}{cc} 1 & 0 \\ 0 & -1 \end{array} \right] \f$
-     */
+    /// \f$ \left[ \begin{array}{cc} 1 & 0 \\ 0 & -1 \end{array} \right] \f$
     Z,
 
-    /**
-     * \f$ \left[ \begin{array}{cc} 0 & 1 \\ 1 & 0 \end{array} \right] \f$
-     */
+    /// \f$ \left[ \begin{array}{cc} 0 & 1 \\ 1 & 0 \end{array} \right] \f$
     X,
 
-    /**
-     * \f$ \left[ \begin{array}{cc} 0 & -i \\ i & 0 \end{array} \right] \f$
-     */
+    /// \f$ \left[ \begin{array}{cc} 0 & -i \\ i & 0 \end{array} \right] \f$
     Y,
 
-    /**
-     * \f$ \left[ \begin{array}{cc} 1 & 0 \\ 0 & i \end{array} \right] =
-     * \mathrm{U1}(\frac12) \f$
-     */
+    /// \f$ \left[ \begin{array}{cc} 1 & 0 \\ 0 & i \end{array} \right] =
+    /// \mathrm{U1}(\frac12) \f$
     S,
 
-    /**
-     * \f$ \left[ \begin{array}{cc} 1 & 0 \\ 0 & -i \end{array} \right] =
-     * \mathrm{U1}(-\frac12) \f$
-     */
+    /// \f$ \left[ \begin{array}{cc} 1 & 0 \\ 0 & -i \end{array} \right] =
+    /// \mathrm{U1}(-\frac12) \f$
     Sdg,
 
-    /**
-     * \f$ \left[ \begin{array}{cc} 1 & 0 \\ 0 & e^{i\pi/4} \end{array} \right]
-     * = \mathrm{U1}(\frac14) \f$
-     */
+    /// \f$ \left[ \begin{array}{cc} 1 & 0 \\ 0 & e^{i\pi/4} \end{array} \right]
+    /// = \mathrm{U1}(\frac14) \f$
     T,
 
-    /**
-     * \f$ \left[ \begin{array}{cc} 1 & 0 \\ 0 & e^{-i\pi/4} \end{array} \right]
-     * \equiv \mathrm{U1}(-\frac14) \f$
-     */
+    /// \f$ \left[ \begin{array}{cc} 1 & 0 \\ 0 & e^{-i\pi/4} \end{array} \right]
+    /// \equiv \mathrm{U1}(-\frac14) \f$
     Tdg,
 
-    /**
-     * \f$ \frac{1}{\sqrt 2} \left[ \begin{array}{cc} 1 & -i \\ -i & 1
-     * \end{array} \right] = \mathrm{Rx}(\frac12) \f$
-     */
+    /// \f$ \frac{1}{\sqrt 2} \left[ \begin{array}{cc} 1 & -i \\ -i & 1
+    /// \end{array} \right] = \mathrm{Rx}(\frac12) \f$
     V,
 
-    /**
-     * \f$ \frac{1}{\sqrt 2} \left[ \begin{array}{cc} 1 & i \\ i & 1 \end{array}
-     * \right] = \mathrm{Rx}(-\frac12) \f$
-     */
+    /// \f$ \frac{1}{\sqrt 2} \left[ \begin{array}{cc} 1 & i \\ i & 1 \end{array}
+    /// \right] = \mathrm{Rx}(-\frac12) \f$
     Vdg,
 
-    /**
-     * \f$ \frac{1}{2} \left[ \begin{array}{cc} 1+i & 1-i \\ 1-i & 1+i
-     * \end{array} \right] = e^{\frac{i\pi}{4}}\mathrm{Rx}(\frac12) \f$
-     */
+    /// \f$ \frac{1}{2} \left[ \begin{array}{cc} 1+i & 1-i \\ 1-i & 1+i
+    /// \end{array} \right] = e^{\frac{i\pi}{4}}\mathrm{Rx}(\frac12) \f$
     SX,
 
-    /**
-     * \f$ \frac{1}{2} \left[ \begin{array}{cc} 1-i & 1+i \\ 1+i & 1-i
-     * \end{array} \right] = e^{\frac{-i\pi}{4}}\mathrm{Rx}(-\frac12) \f$
-     */
+    /// \f$ \frac{1}{2} \left[ \begin{array}{cc} 1-i & 1+i \\ 1+i & 1-i
+    /// \end{array} \right] = e^{\frac{-i\pi}{4}}\mathrm{Rx}(-\frac12) \f$
     SXdg,
 
-    /**
-     * \f$ \frac{1}{\sqrt 2} \left[ \begin{array}{cc} 1 & 1 \\ 1 & -1
-     * \end{array} \right] \f$
-     */
+    /// \f$ \frac{1}{\sqrt 2} \left[ \begin{array}{cc} 1 & 1 \\ 1 & -1
+    /// \end{array} \right] \f$
     H,
 
-    /**
-     * \f$ \mathrm{Rx}(\alpha) = e^{-\frac12 i \pi \alpha X} = \left[
-     * \begin{array}{cc} \cos\frac{\pi\alpha}{2} & -i\sin\frac{\pi\alpha}{2} \\
-     * -i\sin\frac{\pi\alpha}{2} & \cos\frac{\pi\alpha}{2} \end{array} \right]
-     * \f$
-     */
+    /// \f$ \mathrm{Rx}(\alpha) = e^{-\frac12 i \pi \alpha X} = \left[
+    /// \begin{array}{cc} \cos\frac{\pi\alpha}{2} & -i\sin\frac{\pi\alpha}{2} \\
+    /// -i\sin\frac{\pi\alpha}{2} & \cos\frac{\pi\alpha}{2} \end{array} \right]
+    /// \f$
     Rx,
 
-    /**
-     * \f$ \mathrm{Ry}(\alpha) = e^{-\frac12 i \pi \alpha Y} = \left[
-     * \begin{array}{cc} \cos\frac{\pi\alpha}{2} & -\sin\frac{\pi\alpha}{2}
-     * \\ \sin\frac{\pi\alpha}{2} & \cos\frac{\pi\alpha}{2} \end{array} \right]
-     * \f$
-     */
+    /// \f$ \mathrm{Ry}(\alpha) = e^{-\frac12 i \pi \alpha Y} = \left[
+    /// \begin{array}{cc} \cos\frac{\pi\alpha}{2} & -\sin\frac{\pi\alpha}{2}
+    /// \\ \sin\frac{\pi\alpha}{2} & \cos\frac{\pi\alpha}{2} \end{array} \right]
+    /// \f$
     Ry,
 
-    /**
-     * \f$ \mathrm{Rz}(\alpha) = e^{-\frac12 i \pi \alpha Z} = \left[
-     * \begin{array}{cc} e^{-\frac12 i \pi\alpha} & 0 \\ 0 & e^{\frac12 i
-     * \pi\alpha} \end{array} \right] \f$
-     */
+    /// \f$ \mathrm{Rz}(\alpha) = e^{-\frac12 i \pi \alpha Z} = \left[
+    /// \begin{array}{cc} e^{-\frac12 i \pi\alpha} & 0 \\ 0 & e^{\frac12 i
+    /// \pi\alpha} \end{array} \right] \f$
     Rz,
 
-    /**
-     * \f$ \mathrm{U3}(\theta, \phi, \lambda) = \left[ \begin{array}{cc}
-     * \cos\frac{\pi\theta}{2} & -e^{i\pi\lambda} \sin\frac{\pi\theta}{2} \\
-     * e^{i\pi\phi} \sin\frac{\pi\theta}{2} & e^{i\pi(\lambda+\phi)}
-     * \cos\frac{\pi\theta}{2} \end{array} \right] = e^{\frac12
-     * i\pi(\lambda+\phi)} \mathrm{Rz}(\phi) \mathrm{Ry}(\theta)
-     * \mathrm{Rz}(\lambda) \f$
-     */
+    /// \f$ \mathrm{U3}(\theta, \phi, \lambda) = \left[ \begin{array}{cc}
+    /// \cos\frac{\pi\theta}{2} & -e^{i\pi\lambda} \sin\frac{\pi\theta}{2} \\
+    /// e^{i\pi\phi} \sin\frac{\pi\theta}{2} & e^{i\pi(\lambda+\phi)}
+    /// \cos\frac{\pi\theta}{2} \end{array} \right] = e^{\frac12
+    /// i\pi(\lambda+\phi)} \mathrm{Rz}(\phi) \mathrm{Ry}(\theta)
+    /// \mathrm{Rz}(\lambda) \f$
     U3,
 
-    /**
-     * \f$ \mathrm{U2}(\phi, \lambda) = \mathrm{U3}(\frac12, \phi, \lambda)
-     * = e^{\frac12 i\pi(\lambda+\phi)} \mathrm{Rz}(\phi) \mathrm{Ry}(\frac12)
-     * \mathrm{Rz}(\lambda) \f$
-     */
+    /// \f$ \mathrm{U2}(\phi, \lambda) = \mathrm{U3}(\frac12, \phi, \lambda)
+    /// = e^{\frac12 i\pi(\lambda+\phi)} \mathrm{Rz}(\phi) \mathrm{Ry}(\frac12)
+    /// \mathrm{Rz}(\lambda) \f$
     U2,
 
-    /**
-     * \f$ \mathrm{U1}(\lambda) = \mathrm{U3}(0, 0, \lambda) = e^{\frac12
-     * i\pi\lambda} \mathrm{Rz}(\lambda) \f$
-     */
+    /// \f$ \mathrm{U1}(\lambda) = \mathrm{U3}(0, 0, \lambda) = e^{\frac12
+    /// i\pi\lambda} \mathrm{Rz}(\lambda) \f$
     U1,
 
-    /**
-     * \f$ \mathrm{TK1}(\alpha, \beta, \gamma) = \mathrm{Rz}(\alpha)
-     * \mathrm{Rx}(\beta) \mathrm{Rz}(\gamma) \f$
-     */
+    /// \f$ \mathrm{TK1}(\alpha, \beta, \gamma) = \mathrm{Rz}(\alpha)
+    /// \mathrm{Rx}(\beta) \mathrm{Rz}(\gamma) \f$
     TK1,
 
-    /**
-     * Controlled \ref OpType::X
-     */
+    /// Controlled \ref OpType::X
     CX,
 
-    /**
-     * Controlled \ref OpType::Y
-     */
+    /// Controlled \ref OpType::Y
     CY,
 
-    /**
-     * Controlled \ref OpType::Z
-     */
+    /// Controlled \ref OpType::Z
     CZ,
 
-    /**
-     * Controlled \ref OpType::H
-     */
+    /// Controlled \ref OpType::H
     CH,
 
-    /**
-     * Controlled \ref OpType::V
-     *
-     * \f$ \left[ \begin{array}{cccc}
-     * 1 & 0 & 0 & 0 \\
-     * 0 & 1 & 0 & 0 \\
-     * 0 & 0 & \frac{1}{\sqrt 2} & -i \frac{1}{\sqrt 2} \\
-     * 0 & 0 & -i \frac{1}{\sqrt 2} & \frac{1}{\sqrt 2}
-     * \end{array} \right] \f$
-     */
+    /// Controlled \ref OpType::V
+    ///
+    /// \f$ \left[ \begin{array}{cccc}
+    /// 1 & 0 & 0 & 0 \\
+    /// 0 & 1 & 0 & 0 \\
+    /// 0 & 0 & \frac{1}{\sqrt 2} & -i \frac{1}{\sqrt 2} \\
+    /// 0 & 0 & -i \frac{1}{\sqrt 2} & \frac{1}{\sqrt 2}
+    /// \end{array} \right] \f$
     CV,
 
-    /**
-     * Controlled \ref OpType::Vdg
-     *
-     * \f$ \left[ \begin{array}{cccc}
-     * 1 & 0 & 0 & 0 \\
-     * 0 & 1 & 0 & 0 \\
-     * 0 & 0 & \frac{1}{\sqrt 2} & i \frac{1}{\sqrt 2} \\
-     * 0 & 0 & i \frac{1}{\sqrt 2} & \frac{1}{\sqrt 2}
-     * \end{array} \right] \f$
-     */
+    /// Controlled \ref OpType::Vdg
+    ///
+    /// \f$ \left[ \begin{array}{cccc}
+    /// 1 & 0 & 0 & 0 \\
+    /// 0 & 1 & 0 & 0 \\
+    /// 0 & 0 & \frac{1}{\sqrt 2} & i \frac{1}{\sqrt 2} \\
+    /// 0 & 0 & i \frac{1}{\sqrt 2} & \frac{1}{\sqrt 2}
+    /// \end{array} \right] \f$
     CVdg,
 
-    /**
-     * Controlled \ref OpType::SX
-     *
-     * \f$ \left[ \begin{array}{cccc}
-     * 1 & 0 & 0 & 0 \\
-     * 0 & 1 & 0 & 0 \\
-     * 0 & 0 & \frac{1+i}{2} & \frac{1-i}{2} \\
-     * 0 & 0 & \frac{1-i}{2} & \frac{1+i}{2}
-     * \end{array} \right] \f$
-     */
+    /// Controlled \ref OpType::SX
+    ///
+    /// \f$ \left[ \begin{array}{cccc}
+    /// 1 & 0 & 0 & 0 \\
+    /// 0 & 1 & 0 & 0 \\
+    /// 0 & 0 & \frac{1+i}{2} & \frac{1-i}{2} \\
+    /// 0 & 0 & \frac{1-i}{2} & \frac{1+i}{2}
+    /// \end{array} \right] \f$
     CSX,
 
-    /**
-     * Controlled \ref OpType::SXdg
-     *
-     * \f$ \left[ \begin{array}{cccc}
-     * 1 & 0 & 0 & 0 \\
-     * 0 & 1 & 0 & 0 \\
-     * 0 & 0 & \frac{1-i}{2} & \frac{1+i}{2} \\
-     * 0 & 0 & \frac{1+i}{2} & \frac{1-i}{2}
-     * \end{array} \right] \f$
-     */
+    /// Controlled \ref OpType::SXdg
+    ///
+    /// \f$ \left[ \begin{array}{cccc}
+    /// 1 & 0 & 0 & 0 \\
+    /// 0 & 1 & 0 & 0 \\
+    /// 0 & 0 & \frac{1-i}{2} & \frac{1+i}{2} \\
+    /// 0 & 0 & \frac{1+i}{2} & \frac{1-i}{2}
+    /// \end{array} \right] \f$
     CSXdg,
 
-    /**
-     * Controlled \ref OpType::Rz
-     *
-     * \f$ \mathrm{CRz}(\alpha) = \left[ \begin{array}{cccc} 1 & 0 & 0 & 0 \\ 0
-     * & 1 & 0 & 0 \\ 0 & 0 & e^{-\frac12 i \pi\alpha} & 0 \\ 0 & 0 & 0 &
-     * e^{\frac12 i \pi\alpha} \end{array} \right] \f$
-     *
-     * The phase parameter \f$ \alpha \f$ is defined modulo \f$ 4 \f$.
-     */
+    /// Controlled \ref OpType::Rz
+    ///
+    /// \f$ \mathrm{CRz}(\alpha) = \left[ \begin{array}{cccc} 1 & 0 & 0 & 0 \\ 0
+    /// & 1 & 0 & 0 \\ 0 & 0 & e^{-\frac12 i \pi\alpha} & 0 \\ 0 & 0 & 0 &
+    /// e^{\frac12 i \pi\alpha} \end{array} \right] \f$
+    ///
+    /// The phase parameter \f$ \alpha \f$ is defined modulo \f$ 4 \f$.
     CRz,
 
-    /**
-     * Controlled \ref OpType::Rx
-     *
-     * \f$ \mathrm{CRx}(\alpha) = \left[ \begin{array}{cccc} 1 & 0 & 0 & 0 \\ 0
-     * & 1 & 0 & 0 \\ 0 & 0 & \cos \frac{\pi \alpha}{2} & -i \sin \frac{\pi
-     * \alpha}{2}
-     * \\ 0 & 0 & -i \sin \frac{\pi \alpha}{2}  & \cos \frac{\pi \alpha}{2}
-     * \end{array} \right] \f$
-     *
-     * The phase parameter \f$ \alpha \f$ is defined modulo \f$ 4 \f$.
-     */
+    /// Controlled \ref OpType::Rx
+    ///
+    /// \f$ \mathrm{CRx}(\alpha) = \left[ \begin{array}{cccc} 1 & 0 & 0 & 0 \\ 0
+    /// & 1 & 0 & 0 \\ 0 & 0 & \cos \frac{\pi \alpha}{2} & -i \sin \frac{\pi
+    /// \alpha}{2}
+    /// \\ 0 & 0 & -i \sin \frac{\pi \alpha}{2}  & \cos \frac{\pi \alpha}{2}
+    /// \end{array} \right] \f$
+    ///
+    /// The phase parameter \f$ \alpha \f$ is defined modulo \f$ 4 \f$.
     CRx,
 
-    /**
-     * Controlled \ref OpType::Ry
-     *
-     * \f$ \mathrm{CRy}(\alpha) = \left[ \begin{array}{cccc} 1 & 0 & 0 & 0 \\ 0
-     * & 1 & 0 & 0 \\ 0 & 0 & \cos \frac{\pi \alpha}{2} & -\sin \frac{\pi
-     * \alpha}{2}
-     * \\ 0 & 0 & \sin \frac{\pi \alpha}{2}  & \cos \frac{\pi \alpha}{2}
-     * \end{array} \right] \f$
-     *
-     * The phase parameter \f$ \alpha \f$ is defined modulo \f$ 4 \f$.
-     */
+    /// Controlled \ref OpType::Ry
+    ///
+    /// \f$ \mathrm{CRy}(\alpha) = \left[ \begin{array}{cccc} 1 & 0 & 0 & 0 \\ 0
+    /// & 1 & 0 & 0 \\ 0 & 0 & \cos \frac{\pi \alpha}{2} & -\sin \frac{\pi
+    /// \alpha}{2}
+    /// \\ 0 & 0 & \sin \frac{\pi \alpha}{2}  & \cos \frac{\pi \alpha}{2}
+    /// \end{array} \right] \f$
+    ///
+    /// The phase parameter \f$ \alpha \f$ is defined modulo \f$ 4 \f$.
     CRy,
 
-    /**
-     * Controlled \ref OpType::U1
-     *
-     * \f$ \mathrm{CU1}(\alpha) = \left[ \begin{array}{cccc} 1 & 0 & 0 & 0 \\ 0
-     * & 1 & 0 & 0 \\ 0 & 0 & 1 & 0 \\ 0 & 0 & 0 & e^{i\pi\alpha} \end{array}
-     * \right] \f$
-     */
+    /// Controlled \ref OpType::U1
+    ///
+    /// \f$ \mathrm{CU1}(\alpha) = \left[ \begin{array}{cccc} 1 & 0 & 0 & 0 \\ 0
+    /// & 1 & 0 & 0 \\ 0 & 0 & 1 & 0 \\ 0 & 0 & 0 & e^{i\pi\alpha} \end{array}
+    /// \right] \f$
     CU1,
 
-    /**
-     * Controlled \ref OpType::U3
-     */
+    /// Controlled \ref OpType::U3
     CU3,
 
-    /**
-     * \f$ \alpha \mapsto e^{-\frac12 i \pi\alpha Z^{\otimes n}} \f$
-     */
+    /// \f$ \alpha \mapsto e^{-\frac12 i \pi\alpha Z^{\otimes n}} \f$
     PhaseGadget,
 
-    /**
-     * Controlled \ref OpType::CX
-     */
+    /// Controlled \ref OpType::CX
     CCX,
 
-    /**
-     * Swap two qubits
-     */
+    /// Swap two qubits
     SWAP,
 
-    /**
-     * Controlled \ref OpType::SWAP
-     */
+    /// Controlled \ref OpType::SWAP
     CSWAP,
 
-    /**
-     * Three-qubit gate that swaps the first and third qubits
-     */
+    /// Three-qubit gate that swaps the first and third qubits
     BRIDGE,
 
-    /**
-     * Identity
-     */
+    /// Identity
     #[allow(non_camel_case_types)]
     noop,
 
-    /**
-     * Measure a qubit, producing a classical output
-     */
+    /// Measure a qubit, producing a classical output
     Measure,
 
-    /**
-     * Measure a qubit producing no output
-     */
+    /// Measure a qubit producing no output
     Collapse,
 
-    /**
-     * Reset a qubit to the zero state
-     */
+    /// Reset a qubit to the zero state
     Reset,
 
-    /**
-     * \f$ \frac{1}{\sqrt 2} \left[ \begin{array}{cccc} 0 & 0 & 1 & i \\ 0 & 0 &
-     * i & 1 \\ 1 & -i & 0 & 0 \\ -i & 1 & 0 & 0 \end{array} \right] \f$
-     */
+    /// \f$ \frac{1}{\sqrt 2} \left[ \begin{array}{cccc} 0 & 0 & 1 & i \\ 0 & 0 &
+    /// i & 1 \\ 1 & -i & 0 & 0 \\ -i & 1 & 0 & 0 \end{array} \right] \f$
     ECR,
 
-    /**
-     * \f$ \alpha \mapsto e^{\frac14 i \pi\alpha (X \otimes X + Y \otimes Y)}
-     * = \left[ \begin{array}{cccc} 1 & 0 & 0 & 0 \\ 0 & \cos\frac{\pi\alpha}{2}
-     * & i\sin\frac{\pi\alpha}{2} & 0 \\ 0 & i\sin\frac{\pi\alpha}{2} &
-     * \cos\frac{\pi\alpha}{2} & 0 \\ 0 & 0 & 0 & 1 \end{array} \right] \f$
-     *
-     * Also known as an XY gate.
-     */
+    /// \f$ \alpha \mapsto e^{\frac14 i \pi\alpha (X \otimes X + Y \otimes Y)}
+    /// = \left[ \begin{array}{cccc} 1 & 0 & 0 & 0 \\ 0 & \cos\frac{\pi\alpha}{2}
+    /// & i\sin\frac{\pi\alpha}{2} & 0 \\ 0 & i\sin\frac{\pi\alpha}{2} &
+    /// \cos\frac{\pi\alpha}{2} & 0 \\ 0 & 0 & 0 & 1 \end{array} \right] \f$
+    ///
+    /// Also known as an XY gate.
     ISWAP,
 
-    /**
-     * \f$ (\alpha, \beta) \mapsto \mathrm{Rz}(\beta) \mathrm{Rx}(\alpha)
-     * \mathrm{Rz}(-\beta) \f$
-     */
+    /// \f$ (\alpha, \beta) \mapsto \mathrm{Rz}(\beta) \mathrm{Rx}(\alpha)
+    /// \mathrm{Rz}(-\beta) \f$
     PhasedX,
 
-    /**
-     * PhasedX gates on multiple qubits
-     */
+    /// PhasedX gates on multiple qubits
     NPhasedX,
 
-    /**
-     * \f$ \mathrm{ZZPhase}(\frac12) \f$
-     */
+    /// \f$ \mathrm{ZZPhase}(\frac12) \f$
     ZZMax,
 
-    /**
-     * \f$ \alpha \mapsto e^{-\frac12 i \pi\alpha (X \otimes X)} = \left[
-     * \begin{array}{cccc} \cos\frac{\pi\alpha}{2} & 0 & 0 &
-     * -i\sin\frac{\pi\alpha}{2} \\ 0 & \cos\frac{\pi\alpha}{2} &
-     * -i\sin\frac{\pi\alpha}{2} & 0 \\ 0 & -i\sin\frac{\pi\alpha}{2} &
-     * \cos\frac{\pi\alpha}{2} & 0 \\ -i\sin\frac{\pi\alpha}{2} & 0 & 0 &
-     * \cos\frac{\pi\alpha}{2} \end{array} \right] \f$
-     */
+    /// \f$ \alpha \mapsto e^{-\frac12 i \pi\alpha (X \otimes X)} = \left[
+    /// \begin{array}{cccc} \cos\frac{\pi\alpha}{2} & 0 & 0 &
+    /// -i\sin\frac{\pi\alpha}{2} \\ 0 & \cos\frac{\pi\alpha}{2} &
+    /// -i\sin\frac{\pi\alpha}{2} & 0 \\ 0 & -i\sin\frac{\pi\alpha}{2} &
+    /// \cos\frac{\pi\alpha}{2} & 0 \\ -i\sin\frac{\pi\alpha}{2} & 0 & 0 &
+    /// \cos\frac{\pi\alpha}{2} \end{array} \right] \f$
     XXPhase,
 
-    /**
-     * \f$ \alpha \mapsto e^{-\frac12 i \pi\alpha (Y \otimes Y)} = \left[
-     * \begin{array}{cccc} \cos\frac{\pi\alpha}{2} & 0 & 0 &
-     * i\sin\frac{\pi\alpha}{2} \\ 0 & \cos\frac{\pi\alpha}{2} &
-     * -i\sin\frac{\pi\alpha}{2} & 0 \\ 0 & -i\sin\frac{\pi\alpha}{2} &
-     * \cos\frac{\pi\alpha}{2} & 0 \\ i\sin\frac{\pi\alpha}{2} & 0 & 0 &
-     * \cos\frac{\pi\alpha}{2} \end{array} \right] \f$
-     */
+    /// \f$ \alpha \mapsto e^{-\frac12 i \pi\alpha (Y \otimes Y)} = \left[
+    /// \begin{array}{cccc} \cos\frac{\pi\alpha}{2} & 0 & 0 &
+    /// i\sin\frac{\pi\alpha}{2} \\ 0 & \cos\frac{\pi\alpha}{2} &
+    /// -i\sin\frac{\pi\alpha}{2} & 0 \\ 0 & -i\sin\frac{\pi\alpha}{2} &
+    /// \cos\frac{\pi\alpha}{2} & 0 \\ i\sin\frac{\pi\alpha}{2} & 0 & 0 &
+    /// \cos\frac{\pi\alpha}{2} \end{array} \right] \f$
     YYPhase,
 
-    /**
-     * \f$ \alpha \mapsto e^{-\frac12 i \pi\alpha (Z \otimes Z)} = \left[
-     * \begin{array}{cccc} e^{-\frac12 i \pi\alpha} & 0 & 0 & 0 \\ 0 &
-     * e^{\frac12 i \pi\alpha} & 0 & 0 \\ 0 & 0 & e^{\frac12 i \pi\alpha} & 0 \\ 0
-     * & 0 & 0 & e^{-\frac12 i \pi\alpha} \end{array} \right] \f$
-     */
+    /// \f$ \alpha \mapsto e^{-\frac12 i \pi\alpha (Z \otimes Z)} = \left[
+    /// \begin{array}{cccc} e^{-\frac12 i \pi\alpha} & 0 & 0 & 0 \\ 0 &
+    /// e^{\frac12 i \pi\alpha} & 0 & 0 \\ 0 & 0 & e^{\frac12 i \pi\alpha} & 0 \\ 0
+    /// & 0 & 0 & e^{-\frac12 i \pi\alpha} \end{array} \right] \f$
     ZZPhase,
 
-    /**
-     * Three-qubit phase MSGate
-     */
+    /// Three-qubit phase MSGate
     XXPhase3,
 
-    /**
-     * \f$ \alpha \mapsto e^{-\frac12 i\pi\alpha \cdot \mathrm{SWAP}} = \left[
-     * \begin{array}{cccc} e^{-\frac12 i \pi\alpha} & 0 & 0 & 0 \\ 0 &
-     * \cos\frac{\pi\alpha}{2} & -i\sin\frac{\pi\alpha}{2} & 0 \\ 0 &
-     * -i\sin\frac{\pi\alpha}{2} & \cos\frac{\pi\alpha}{2} & 0 \\ 0 & 0 & 0 &
-     * e^{-\frac12 i \pi\alpha} \end{array} \right] \f$
-     */
+    /// \f$ \alpha \mapsto e^{-\frac12 i\pi\alpha \cdot \mathrm{SWAP}} = \left[
+    /// \begin{array}{cccc} e^{-\frac12 i \pi\alpha} & 0 & 0 & 0 \\ 0 &
+    /// \cos\frac{\pi\alpha}{2} & -i\sin\frac{\pi\alpha}{2} & 0 \\ 0 &
+    /// -i\sin\frac{\pi\alpha}{2} & \cos\frac{\pi\alpha}{2} & 0 \\ 0 & 0 & 0 &
+    /// e^{-\frac12 i \pi\alpha} \end{array} \right] \f$
     ESWAP,
 
-    /**
-     * \f$ (\alpha, \beta) \mapsto \left[ \begin{array}{cccc} 1 & 0 & 0 & 0 \\ 0
-     * & \cos \pi\alpha & -i\sin  \pi\alpha & 0 \\ 0 &
-     * -i\sin \pi\alpha & \cos \pi\alpha & 0 \\ 0 & 0 & 0 &
-     * e^{-i\pi\beta} \end{array} \right] \f$
-     */
+    /// \f$ (\alpha, \beta) \mapsto \left[ \begin{array}{cccc} 1 & 0 & 0 & 0 \\ 0
+    /// & \cos \pi\alpha & -i\sin  \pi\alpha & 0 \\ 0 &
+    /// -i\sin \pi\alpha & \cos \pi\alpha & 0 \\ 0 & 0 & 0 &
+    /// e^{-i\pi\beta} \end{array} \right] \f$
     FSim,
 
-    /**
-     * Fixed instance of a \ref OpType::FSim gate with parameters
-     * \f$ (\frac12, \frac16) \f$:
-     * \f$ \left[ \begin{array}{cccc} 1 & 0 & 0 & 0 \\ 0 & 0 & -i & 0 \\ 0 & -i
-     * & 0 & 0 \\ 0 & 0 & 0 & e^{-i\pi/6} \end{array} \right] \f$
-     */
+    /// Fixed instance of a \ref OpType::FSim gate with parameters
+    /// \f$ (\frac12, \frac16) \f$:
+    /// \f$ \left[ \begin{array}{cccc} 1 & 0 & 0 & 0 \\ 0 & 0 & -i & 0 \\ 0 & -i
+    /// & 0 & 0 \\ 0 & 0 & 0 & e^{-i\pi/6} \end{array} \right] \f$
     Sycamore,
 
-    /**
-     * Fixed instance of a \ref OpType::ISWAP gate with parameter \f$ 1.0 \f$:
-     * \f$ \left[ \begin{array}{cccc} 1 & 0 & 0 & 0 \\ 0 & 0 & i & 0 \\ 0 & i
-     * & 0 & 0 \\ 0 & 0 & 0 & 1 \end{array} \right] \f$
-     */
+    /// Fixed instance of a \ref OpType::ISWAP gate with parameter \f$ 1.0 \f$:
+    /// \f$ \left[ \begin{array}{cccc} 1 & 0 & 0 & 0 \\ 0 & 0 & i & 0 \\ 0 & i
+    /// & 0 & 0 \\ 0 & 0 & 0 & 1 \end{array} \right] \f$
     ISWAPMax,
 
+    /// ISwap gate with extra `Rz`s on each qubit
+    // TODO: Matrix description
     PhasedISWAP,
 
-    /**
-     * Multiply-controlled \ref OpType::Ry
-     *
-     * The phase parameter is defined modulo \f$ 4 \f$.
-     */
+    /// Multiply-controlled \ref OpType::Ry
+    ///
+    /// The phase parameter is defined modulo \f$ 4 \f$.
     CnRy,
 
-    /**
-     * Multiply-controlled \ref OpType::X
-     */
+    /// Multiply-controlled \ref OpType::X
     CnX,
 
-    /**
-     * See \ref CircBox
-     */
+    /// See \ref CircBox
     CircBox,
 
-    /**
-     * See \ref Unitary1qBox
-     */
+    /// See \ref Unitary1qBox
     Unitary1qBox,
 
-    /**
-     * See \ref Unitary2qBox
-     */
+    /// See \ref Unitary2qBox
     Unitary2qBox,
 
-    /**
-     * See \ref Unitary3qBox
-     */
+    /// See \ref Unitary3qBox
     Unitary3qBox,
 
-    /**
-     * See \ref ExpBox
-     */
+    /// See \ref ExpBox
     ExpBox,
 
-    /**
-     * See \ref PauliExpBox
-     */
+    /// See \ref PauliExpBox
     PauliExpBox,
 
-    /**
-     * NYI
-     */
+    /// NYI
     CliffBox,
 
-    /**
-     * See \ref CustomGate
-     */
+    /// See \ref CustomGate
     CustomGate,
 
-    /**
-     * See \ref PhasePolyBox
-     */
+    /// See \ref PhasePolyBox
     PhasePolyBox,
 
-    /**
-     * See \ref QControlBox
-     */
+    /// See \ref QControlBox
     QControlBox,
 
-    /**
-     * See \ref ClassicalExpBox
-     */
+    /// See \ref ClassicalExpBox
     ClassicalExpBox,
 
-    /**
-     * See \ref Conditional
-     */
+    /// See \ref Conditional
     Conditional,
 
-    /**
-     * See \ref ProjectorAssertionBox
-     */
+    /// See \ref ProjectorAssertionBox
     ProjectorAssertionBox,
 
-    /**
-     * See \ref StabiliserAssertionBox
-     */
+    /// See \ref StabiliserAssertionBox
     StabiliserAssertionBox,
 
-    /**
-     * See \ref UnitaryTableauBox
-     */
+    /// See \ref UnitaryTableauBox
     UnitaryTableauBox,
 
+    ///
     #[cfg(feature = "tket2ops")]
     AngleAdd,
+    ///
     #[cfg(feature = "tket2ops")]
     AngleMul,
+    ///
     #[cfg(feature = "tket2ops")]
     AngleNeg,
+    ///
     #[cfg(feature = "tket2ops")]
     QuatMul,
+    ///
     #[cfg(feature = "tket2ops")]
     RxF64,
+    ///
     #[cfg(feature = "tket2ops")]
     RzF64,
+    ///
     #[cfg(feature = "tket2ops")]
     Rotation,
+    ///
     #[cfg(feature = "tket2ops")]
     ToRotation,
+    ///
     #[cfg(feature = "tket2ops")]
     Copy,
+    ///
     #[cfg(feature = "tket2ops")]
     Const,
 }

--- a/src/optype.rs
+++ b/src/optype.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 /// Operation types in a quantum circuit.
 #[cfg_attr(feature = "pyo3", pyclass(name = "RsOpType"))]
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub enum OpType {
     /// Quantum input node of the circuit
     Input,
@@ -398,37 +399,6 @@ pub enum OpType {
 
     /// See \ref UnitaryTableauBox
     UnitaryTableauBox,
-
-    ///
-    #[cfg(feature = "tket2ops")]
-    AngleAdd,
-    ///
-    #[cfg(feature = "tket2ops")]
-    AngleMul,
-    ///
-    #[cfg(feature = "tket2ops")]
-    AngleNeg,
-    ///
-    #[cfg(feature = "tket2ops")]
-    QuatMul,
-    ///
-    #[cfg(feature = "tket2ops")]
-    RxF64,
-    ///
-    #[cfg(feature = "tket2ops")]
-    RzF64,
-    ///
-    #[cfg(feature = "tket2ops")]
-    Rotation,
-    ///
-    #[cfg(feature = "tket2ops")]
-    ToRotation,
-    ///
-    #[cfg(feature = "tket2ops")]
-    Copy,
-    ///
-    #[cfg(feature = "tket2ops")]
-    Const,
 }
 
 #[cfg(feature = "pyo3")]

--- a/src/pytket.rs
+++ b/src/pytket.rs
@@ -1,14 +1,18 @@
+//! Python bindings for the serializable circuits.
+
 use crate::circuit_json::SerialCircuit;
 use pyo3::prelude::*;
 use pythonize::{depythonize, pythonize};
 
 // #[pymethods]
 impl SerialCircuit {
+    /// Create a new `SerialCircuit` from a `pytket.Circuit`.
     pub fn _from_tket1(c: Py<PyAny>) -> Self {
         Python::with_gil(|py| depythonize(c.call_method0(py, "to_dict").unwrap().as_ref(py)))
             .unwrap()
     }
 
+    /// Convert a `SerialCircuit` to a `pytket.Circuit`.
     pub fn to_tket1(&self) -> PyResult<Py<PyAny>> {
         Python::with_gil(|py| {
             let dict = pythonize(py, self).unwrap();


### PR DESCRIPTION
Copied what I could from TKET's doc.

There is no math rendering for the op definitions, we'll need to add something like [katex_doc](https://docs.rs/katex-doc/0.1.0/katex_doc/) later.

Also deletes the outdated `tket2ops` feature (#11).