### PR TITLE
ci: Bring in CI updates from other repos

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "cargo" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+    commit-message:
+      # Use a conventional commit tag
+      prefix: "chore(deps)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches:
       - main
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch: {}
 
 env:
@@ -39,14 +41,17 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        include:
-          - rust: 1.60.0
-            cache: true
-          - rust: stable
-            cache: true
+        rust: ['1.70', stable, beta]
+        # workaround to ignore non-stable tests when running the merge queue checks
+        # see: https://github.community/t/how-to-conditionally-include-exclude-items-in-matrix-eg-based-on-branch/16853/6
+        isMerge:
+            - ${{ github.event_name == 'merge_group' }}
+        exclude:
+          - rust: '1.70'
+            isMerge: true
           - rust: beta
-            cache: true
-
+            isMerge: true
+    name: tests (Rust ${{ matrix.rust }})
     steps:
       - uses: actions/checkout@v3
       - id: toolchain
@@ -56,7 +61,6 @@ jobs:
       - name: Configure default rust toolchain
         run: rustup override set ${{steps.toolchain.outputs.name}}
       - uses: Swatinem/rust-cache@v2
-        if: ${{ matrix.cache }}
         with:
           prefix-key: v0-rust-${{ matrix.rust }}
       - name: Build with no features

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,72 @@
+name: Check Conventional Commits format
+
+on:
+  pull_request_target:
+    branches:
+      - main 
+    types:
+      - opened
+      - edited
+      - synchronize
+      - labeled
+      - unlabeled
+  merge_group:
+    types: [checks_requested]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  main:
+    name: Validate Conventional Commit PR title
+    runs-on: ubuntu-latest
+    # The action does not support running on merge_group events,
+    # but if the check succeeds in the PR there is no need to check it again.
+    if: github.event_name == 'pull_request_target'
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Configure which types are allowed (newline-delimited).
+          # Default: https://github.com/commitizen/conventional-commit-types
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            ci
+            chore
+            revert
+          # Configure which scopes are allowed (newline-delimited).
+          # These are regex patterns auto-wrapped in `^ $`.
+          #scopes: |
+          #  .*
+          # Configure that a scope must always be provided.
+          requireScope: false
+          # Configure which scopes are disallowed in PR titles (newline-delimited).
+          # For instance by setting the value below, `chore(release): ...` (lowercase)
+          # and `ci(e2e,release): ...` (unknown scope) will be rejected.
+          # These are regex patterns auto-wrapped in `^ $`.
+          #disallowScopes: |
+          #  release
+          #  [A-Z]+
+          # Configure additional validation for the subject based on a regex.
+          # This example ensures the subject doesn't start with an uppercase character.
+          #subjectPattern: ^(?![A-Z]).+$
+          # If `subjectPattern` is configured, you can use this property to override
+          # the default error message that is shown when the pattern doesn't match.
+          # The variables `subject` and `title` can be used within the message.
+          #subjectPatternError: |
+          #  The subject "{subject}" found in the pull request title "{title}"
+          #  didn't match the configured pattern. Please ensure that the subject
+          #  doesn't start with an uppercase character.
+          # If the PR contains one of these newline-delimited labels, the
+          # validation is skipped. If you want to rerun the validation when
+          # labels change, you might want to use the `labeled` and `unlabeled`
+          # event triggers in your workflow.
+          ignoreLabels: |
+            ignore-semantic-pull-request

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "tket-json-rs"
 version = "0.1.0"
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.70"
 
 readme = "README.md"
 documentation = "https://docs.rs/tket-json-rs/"

--- a/README.md
+++ b/README.md
@@ -26,5 +26,5 @@ This project is licensed under Apache License, Version 2.0 ([LICENSE][] or http:
   [docs]: https://img.shields.io/docsrs/tket-json-rs/latest
   [crates]: https://img.shields.io/crates/v/tket-json-rs
   [LICENSE]: LICENCE
-  [msrv]: https://img.shields.io/badge/rust-1.60.0%2B-blue.svg?maxAge=3600
+  [msrv]: https://img.shields.io/badge/rust-1.70.0%2B-blue.svg?maxAge=3600
   [RELEASES]: RELEASES.rst


### PR DESCRIPTION
- Add dependabot
- Enable merge queue triggers
- Enable conventional commit PR name checks

Also pushes MSRV to 1.70