### PR TITLE
chore!: Update pyo3 to 0.21

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ name = "tket_json_rs"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 uuid = { version = "1.4", features = ["serde"] }
-pyo3 = { version = "0.20.0", optional = true }
-pythonize = { version = "0.20.0", optional = true }
+pyo3 = { version = "0.21.1", optional = true }
+pythonize = { version = "0.21.1", optional = true }
 
 
 [features]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Serializable Rust definition for circuits and operations of the
 
 ## Features
 
--   `pyo3`: Enable Python bindings via pyo3.
+-   `pyo3`: Enable Python bindings and `pytket.Circuit` conversion via pyo3.
 
 ## Recent Changes
 

--- a/src/pytket.rs
+++ b/src/pytket.rs
@@ -2,12 +2,12 @@
 
 use crate::circuit_json::SerialCircuit;
 use pyo3::prelude::*;
-use pythonize::{depythonize, pythonize};
+use pythonize::{depythonize_bound, pythonize};
 
 impl SerialCircuit {
     /// Create a new `SerialCircuit` from a `pytket.Circuit`.
-    pub fn from_tket1(circ: &PyAny) -> PyResult<Self> {
-        let circ = depythonize(circ.call_method0("to_dict").unwrap())?;
+    pub fn from_tket1(circ: &Bound<PyAny>) -> PyResult<Self> {
+        let circ = depythonize_bound(circ.call_method0("to_dict").unwrap())?;
         Ok(circ)
     }
 
@@ -15,13 +15,13 @@ impl SerialCircuit {
     ///
     /// Utility function that calls [`SerialCircuit::from_tket1`] after acquiring the GIL.
     pub fn from_tket1_with_gil(circ: Py<PyAny>) -> PyResult<Self> {
-        Python::with_gil(|py| Self::from_tket1(circ.as_ref(py)))
+        Python::with_gil(|py| Self::from_tket1(circ.bind(py)))
     }
 
     /// Convert a `SerialCircuit` to a `pytket.Circuit`.
-    pub fn to_tket1<'py>(&self, py: Python<'py>) -> PyResult<&'py PyAny> {
+    pub fn to_tket1<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let dict = pythonize(py, self).unwrap();
-        let circ_module = PyModule::import(py, "pytket.circuit")?;
+        let circ_module = PyModule::import_bound(py, "pytket.circuit")?;
 
         circ_module
             .getattr("Circuit")?


### PR DESCRIPTION
`pyo3 0.21.0` reworked the GIL references to use a new `Bound` smart pointer.

See the migration guide: https://pyo3.rs/v0.21.1/migration.html

BREAKING CHANGE: `pyo3` dependencies must always match, as they all must link to the same native library `python`.