### PR TITLE
fix: Add missing `CnRx` `CnRz` ops

### DIFF
--- a/src/opbox.rs
+++ b/src/opbox.rs
@@ -117,7 +117,7 @@ pub enum OpBox {
         /// The phase polynomial definition.
         /// Represented by a map from bitstring to expression of coefficient.
         phase_polynomial: Vec<Vec<(Bitstring, String)>>,
-        ///
+        /// The additional linear transformation.
         linear_transformation: Matrix,
     },
     /// A user-defined assertion specified by a list of Pauli stabilisers.

--- a/src/optype.rs
+++ b/src/optype.rs
@@ -364,10 +364,14 @@ pub enum OpType {
     // TODO: Matrix description
     PhasedISWAP,
 
-    /// Multiply-controlled [`OpType::Ry`]
-    ///
-    /// The phase parameter is defined modulo \f$ 4 \f$.
+    /// N-controlled [`OpType::Rx`]
+    CnRx,
+
+    /// N-controlled [`OpType::Ry`]
     CnRy,
+
+    /// N-controlled [`OpType::Rz`]
+    CnRz,
 
     /// Multiply-controlled [`OpType::X`]
     CnX,


### PR DESCRIPTION
Closes #46 

drive-by: Fix clippy lint due to missing doc