### PR TITLE
feat!: Classical op params

### DIFF
--- a/src/circuit_json.rs
+++ b/src/circuit_json.rs
@@ -48,6 +48,7 @@ pub struct Matrix<T = f64> {
 /// The units used in a [`ClassicalExp`].
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq, Hash)]
 #[serde(untagged)]
+#[non_exhaustive]
 pub enum ClassicalExpUnit {
     /// Unsigned 32-bit integer.
     U32(u32),
@@ -88,6 +89,7 @@ pub struct Conditional {
 // define `values` and `n_i`.
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq)]
 #[serde(untagged)]
+#[non_exhaustive]
 pub enum Classical {
     /// Multi-bit operation.
     MultiBit {
@@ -136,7 +138,8 @@ pub enum Classical {
 }
 
 /// Serializable operation descriptor.
-#[derive(Deserialize, Serialize, Clone, Debug, PartialEq)]
+#[derive(Deserialize, Serialize, Clone, Debug, Default, PartialEq)]
+#[non_exhaustive]
 pub struct Operation<P = String> {
     /// The type of operation.
     #[serde(rename = "type")]

--- a/src/circuit_json.rs
+++ b/src/circuit_json.rs
@@ -138,7 +138,7 @@ pub enum Classical {
 }
 
 /// Serializable operation descriptor.
-#[derive(Deserialize, Serialize, Clone, Debug, Default, PartialEq)]
+#[derive(Deserialize, Serialize, Clone, Debug, PartialEq)]
 #[non_exhaustive]
 pub struct Operation<P = String> {
     /// The type of operation.
@@ -202,6 +202,21 @@ pub struct SerialCircuit<P = String> {
     pub implicit_permutation: Vec<Permutation>,
 }
 
+impl<P> Default for Operation<P> {
+    fn default() -> Self {
+        Self {
+            op_type: Default::default(),
+            n_qb: None,
+            data: None,
+            params: None,
+            op_box: None,
+            signature: None,
+            conditional: None,
+            classical: None,
+        }
+    }
+}
+
 impl<P> Operation<P> {
     /// Returns a default-initialized Operation with the given type.
     ///
@@ -210,13 +225,7 @@ impl<P> Operation<P> {
     pub fn from_optype(op_type: OpType) -> Self {
         Self {
             op_type,
-            n_qb: None,
-            data: None,
-            params: None,
-            op_box: None,
-            signature: None,
-            conditional: None,
-            classical: None,
+            ..Operation::default()
         }
     }
 }

--- a/src/optype.rs
+++ b/src/optype.rs
@@ -10,7 +10,7 @@ use strum::EnumString;
 
 /// Operation types in a quantum circuit.
 #[cfg_attr(feature = "pyo3", pyclass(name = "RsOpType"))]
-#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq, Hash, EnumString)]
+#[derive(Deserialize, Serialize, Clone, Debug, Default, PartialEq, Eq, Hash, EnumString)]
 #[non_exhaustive]
 pub enum OpType {
     /// Quantum input node of the circuit
@@ -280,6 +280,7 @@ pub enum OpType {
 
     /// Identity
     #[allow(non_camel_case_types)]
+    #[default]
     noop,
 
     /// Measure a qubit, producing a classical output

--- a/tests/data/classical.json
+++ b/tests/data/classical.json
@@ -17,61 +17,9 @@
         {
             "args": [
                 [
-                    "q",
-                    [
-                        0
-                    ]
-                ]
-            ],
-            "op": {
-                "type": "H",
-                "data": "Custom data"
-            }
-        },
-        {
-            "args": [
-                [
-                    "q",
-                    [
-                        0
-                    ]
-                ],
-                [
-                    "q",
-                    [
-                        1
-                    ]
-                ]
-            ],
-            "op": {
-                "type": "CX"
-            }
-        },
-        {
-            "args": [
-                [
-                    "q",
-                    [
-                        0
-                    ]
-                ],
-                [
                     "c",
                     [
                         0
-                    ]
-                ]
-            ],
-            "op": {
-                "type": "Measure"
-            }
-        },
-        {
-            "args": [
-                [
-                    "q",
-                    [
-                        1
                     ]
                 ],
                 [
@@ -82,7 +30,69 @@
                 ]
             ],
             "op": {
-                "type": "Measure"
+                "type": "MultiBit",
+                "classical": {
+                    "op": {
+                        "type": "SetBits",
+                        "classical": {
+                            "values": [
+                                true
+                            ]
+                        }
+                    },
+                    "n": 2
+                }
+            }
+        },
+        {
+            "args": [
+                [
+                    "c",
+                    [
+                        0
+                    ]
+                ],
+                [
+                    "c",
+                    [
+                        1
+                    ]
+                ]
+            ],
+            "op": {
+                "type": "ClassicalTransform",
+                "classical": {
+                    "name": "ClassicalCX",
+                    "n_io": 2,
+                    "values": [
+                        0,
+                        1,
+                        3,
+                        2
+                    ]
+                }
+            }
+        },
+        {
+            "args": [
+                [
+                    "c",
+                    [
+                        0
+                    ]
+                ],
+                [
+                    "c",
+                    [
+                        1
+                    ]
+                ]
+            ],
+            "op": {
+                "type": "CopyBits",
+                "classical": {
+                    "n_i": 2
+                }
             }
         }
     ],

--- a/tests/data/diagonal-box.json
+++ b/tests/data/diagonal-box.json
@@ -67,8 +67,6 @@
             }
         }
     ],
-    "created_qubits": [],
-    "discarded_qubits": [],
     "implicit_permutation": [
         [
             [

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -1,14 +1,16 @@
 //! Roundtrip tests
-use assert_json_diff::assert_json_include;
+use assert_json_diff::assert_json_eq;
 use rstest::rstest;
 use serde_json::Value;
 use tket_json_rs::SerialCircuit;
 
 const SIMPLE: &str = include_str!("data/simple.json");
+const CLASSICAL: &str = include_str!("data/classical.json");
 const DIAGONAL: &str = include_str!("data/diagonal-box.json");
 
 #[rstest]
 #[case::simple(SIMPLE, 4)]
+#[case::classical(CLASSICAL, 3)]
 #[case::diagonal_box(DIAGONAL, 1)]
 fn roundtrip(#[case] json: &str, #[case] num_commands: usize) {
     let initial_json: Value = serde_json::from_str(json).unwrap();
@@ -17,8 +19,7 @@ fn roundtrip(#[case] json: &str, #[case] num_commands: usize) {
     assert_eq!(ser.commands.len(), num_commands);
 
     let reencoded_json = serde_json::to_value(&ser).unwrap();
-    // Do a partial comparison. The re-encoded circuit does not include "created_qubits" nor "discarded_qubits".
-    assert_json_include!(actual: initial_json, expected: reencoded_json);
+    assert_json_eq!(reencoded_json, initial_json);
 
     let reser: SerialCircuit = serde_json::from_value(reencoded_json).unwrap();
 


### PR DESCRIPTION
Closes #53 

drive-by: Add missing `data` field to Operation ([schema](https://github.com/CQCL/tket/blob/a47578ec5d79bb5caf23ef2edee3f587bc3c7d14/schemas/circuit_v1.json#L283-L286)).
drive-by: Remove `created_qubits`/`discarded_qubits` from the test files. Those fields are not in the schema.
drive-by: Mark more structs as `non_exhaustive`, so in the future a change like this does not have to be breaking.

BREAKING CHANGE: Added `data` and `classical` fields to `Operation`. Marked some structs/enums as non_exhaustive.