### PR TITLE
fix: Update ToffoliBox permutation type

### DIFF
--- a/src/circuit_json.rs
+++ b/src/circuit_json.rs
@@ -184,7 +184,7 @@ pub struct Command<P = String> {
 /// Used when defining Toffoli boxes.
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq, Hash)]
 #[serde(transparent)]
-pub struct Permutation(Vec<(Vec<bool>, Vec<bool>)>);
+pub struct Permutation(pub Vec<(Vec<bool>, Vec<bool>)>);
 
 /// An implicit permutation of the elements of a register.
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq, Hash)]

--- a/src/circuit_json.rs
+++ b/src/circuit_json.rs
@@ -180,9 +180,15 @@ pub struct Command<P = String> {
     pub opgroup: Option<String>,
 }
 
-/// A permutation of the elements of a register.
+/// A classic basis state permutation.
+/// Used when defining Toffoli boxes.
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq, Hash)]
-pub struct Permutation(pub Register, pub Register);
+#[serde(transparent)]
+pub struct Permutation(Vec<(Vec<bool>, Vec<bool>)>);
+
+/// An implicit permutation of the elements of a register.
+#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct ImplicitPermutation(pub Register, pub Register);
 
 /// Pytket canonical serialized circuit
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq)]
@@ -199,7 +205,7 @@ pub struct SerialCircuit<P = String> {
     /// Input bit registers.
     pub bits: Vec<Register>,
     /// Implicit permutation of the output qubits.
-    pub implicit_permutation: Vec<Permutation>,
+    pub implicit_permutation: Vec<ImplicitPermutation>,
 }
 
 impl<P> Default for Operation<P> {

--- a/src/opbox.rs
+++ b/src/opbox.rs
@@ -7,7 +7,7 @@
 use std::collections::HashMap;
 
 use crate::circuit_json::{
-    Bitstring, ClassicalExp, CompositeGate, Matrix, Operation, Permutation, Register, SerialCircuit
+    Bitstring, ClassicalExp, CompositeGate, Matrix, Operation, Permutation, Register, SerialCircuit,
 };
 use crate::optype::OpType;
 use serde::{Deserialize, Serialize};

--- a/src/opbox.rs
+++ b/src/opbox.rs
@@ -7,7 +7,7 @@
 use std::collections::HashMap;
 
 use crate::circuit_json::{
-    Bitstring, ClassicalExp, CompositeGate, Matrix, Operation, Permutation, Register, SerialCircuit,
+    Bitstring, ClassicalExp, CompositeGate, Matrix, Operation, Register, SerialCircuit,
 };
 use crate::optype::OpType;
 use serde::{Deserialize, Serialize};

--- a/src/opbox.rs
+++ b/src/opbox.rs
@@ -7,7 +7,7 @@
 use std::collections::HashMap;
 
 use crate::circuit_json::{
-    Bitstring, ClassicalExp, CompositeGate, Matrix, Operation, Register, SerialCircuit,
+    Bitstring, ClassicalExp, CompositeGate, Matrix, Operation, Permutation, Register, SerialCircuit
 };
 use crate::optype::OpType;
 use serde::{Deserialize, Serialize};
@@ -190,7 +190,7 @@ pub enum OpBox {
     ToffoliBox {
         id: BoxID,
         /// The classical basis state permutation.
-        permutation: Vec<(Vec<bool>, Vec<bool>)>,
+        permutation: Permutation,
         // Synthesis strategy. See [`ToffoliBoxSynthStrat`].
         strat: ToffoliBoxSynthStrat,
         // The rotation axis of the multiplexors used in the decomposition. Can

--- a/src/opbox.rs
+++ b/src/opbox.rs
@@ -190,7 +190,7 @@ pub enum OpBox {
     ToffoliBox {
         id: BoxID,
         /// The classical basis state permutation.
-        permutation: Permutation,
+        permutation: Vec<(Vec<bool>, Vec<bool>)>,
         // Synthesis strategy. See [`ToffoliBoxSynthStrat`].
         strat: ToffoliBoxSynthStrat,
         // The rotation axis of the multiplexors used in the decomposition. Can


### PR DESCRIPTION
Updated ToffoliBox permutation type to match tket schema and nexus dataclasses. This inconsistency caused failures when getting circuits that include a ToffoliBox from the database.