### PR TITLE
ci: Dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
       # Use a conventional commit tag
       prefix: "chore(deps)"
     groups:
-      hugr:
+      pyo3:
         patterns: ["pyo3", "pythonize"]
       dev:
         dependency-type: "development"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,22 @@ updates:
     commit-message:
       # Use a conventional commit tag
       prefix: "chore(deps)"
+    groups:
+      hugr:
+        patterns: ["pyo3", "pythonize"]
+      dev:
+        dependency-type: "development"
+        update-types: ["patch", "minor"]
+      patch:
+        update-types: ["patch"]
+      minor:
+        update-types: ["minor"]
+      # Major updates still generate individual PRs
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      # Use a conventional commit tag
+      prefix: "ci(deps)"


### PR DESCRIPTION
`pyo3` and `pythonize` need to be updated together, as there can only be one `pyo3` version in the dependency tree.

Adds a dependabot update group for them, as well as the group config we setup for `tket2`.