### PR TITLE
ci: Quicker missing op notifications

### DIFF
--- a/.github/workflows/missing-ops.yml
+++ b/.github/workflows/missing-ops.yml
@@ -60,7 +60,9 @@ jobs:
     if: ${{ needs.missing-optypes.outputs.should_notify == 'true' }}
     with:
       channel-id: 'C04SHCL4FKP'
-      slack-message: '`tket-json-rs` is missing OpType definitions. See the failing check for more info.\nhttps://github.com/CQCL/tket-json-rs/actions/workflows/missing-ops.yml'
+      slack-message: |
+        `tket-json-rs` is missing OpType definitions.
+        See <https://github.com/CQCL/tket-json-rs/actions/runs/${{ github.run_id }}|the failing check> for more info.
       # An unique identifier for the message type, to use in rate limiting.
       message-label: "missing-op"
       # Rate-limit the message to once per week

--- a/.github/workflows/missing-ops.yml
+++ b/.github/workflows/missing-ops.yml
@@ -55,7 +55,7 @@ jobs:
           result-encoding: string
 
   notify-slack:
-    uses: CQCL/hugrverse-actions/.github/workflows/slack-notifier.yml@ab/slack-notifier
+    uses: CQCL/hugrverse-actions/.github/workflows/slack-notifier.yml@main
     needs: missing-optypes
     if: ${{ needs.missing-optypes.outputs.should_notify == 'true' && ( github.event_name == 'schedule' || github.event_name == 'push' ) }}
     with:

--- a/.github/workflows/missing-ops.yml
+++ b/.github/workflows/missing-ops.yml
@@ -9,8 +9,8 @@ on:
       - main
   workflow_dispatch: {}
   schedule:
-    # 08:00 weekly on Monday
-    - cron: '0 8 * * 1'
+    # 08:00 daily
+    - cron: '0 8 * * *'
 
 env:
   CARGO_TERM_COLOR: always
@@ -21,6 +21,7 @@ jobs:
   missing-optypes:
     name: Check for missing op type definitions
     runs-on: ubuntu-latest
+    continue-on-error: true
     outputs:
       should_notify: ${{ steps.check_status.outputs.result }}
     steps:
@@ -54,20 +55,15 @@ jobs:
           result-encoding: string
 
   notify-slack:
+    uses: CQCL/hugrverse-actions/.github/workflows/slack-notifier.yml@ab/slack-notifier
     needs: missing-optypes
-    runs-on: ubuntu-latest
-    if: ${{ needs.missing-optypes.outputs.should_notify == 'true' && github.event_name == 'schedule' }}
-    steps:
-      - name: Compose the slack message
-        id: make_msg
-        run: |
-          MSG="msg=`tket-json-rs` is missing OpType definitions. See the failing check for more info.\nhttps://github.com/CQCL/tket-json-rs/actions/workflows/missing-ops.yml"
-          echo $MSG
-          echo $MSG  >> "$GITHUB_OUTPUT"
-      - name: Send notification
-        uses: slackapi/slack-github-action@v1.27.0
-        with:
-          channel-id: 'C040CRWH9FF'
-          slack-message: ${{ steps.make_msg.outputs.msg }}
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+    if: ${{ needs.missing-optypes.outputs.should_notify == 'true' }}
+    with:
+      channel-id: 'C04SHCL4FKP'
+      slack-message: '`tket-json-rs` is missing OpType definitions. See the failing check for more info.\nhttps://github.com/CQCL/tket-json-rs/actions/workflows/missing-ops.yml'
+      # An unique identifier for the message type, to use in rate limiting.
+      message-label: "missing-op"
+      # Rate-limit the message to once per week
+      timeout-minutes: 10080
+    secrets:
+        SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/missing-ops.yml
+++ b/.github/workflows/missing-ops.yml
@@ -57,15 +57,16 @@ jobs:
   notify-slack:
     uses: CQCL/hugrverse-actions/.github/workflows/slack-notifier.yml@ab/slack-notifier
     needs: missing-optypes
-    if: ${{ needs.missing-optypes.outputs.should_notify == 'true' }}
+    if: ${{ needs.missing-optypes.outputs.should_notify == 'true' && ( github.event_name == 'schedule' || github.event_name == 'push' ) }}
     with:
-      channel-id: 'C04SHCL4FKP'
+      channel-id: 'C040CRWH9FF'
       slack-message: |
         `tket-json-rs` is missing OpType definitions.
         See <https://github.com/CQCL/tket-json-rs/actions/runs/${{ github.run_id }}|the failing check> for more info.
-      # An unique identifier for the message type, to use in rate limiting.
-      message-label: "missing-op"
       # Rate-limit the message to once per week
       timeout-minutes: 10080
+      # A repository variable used to store the last message timestamp.
+      timeout-variable: "MISSING_OPS_MSG_SENT"
     secrets:
         SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        GITHUB_PAT: ${{ secrets.HUGRBOT_PAT }}

--- a/.github/workflows/missing-ops.yml
+++ b/.github/workflows/missing-ops.yml
@@ -61,7 +61,7 @@ jobs:
     with:
       channel-id: 'C040CRWH9FF'
       slack-message: |
-        `tket-json-rs` is missing OpType definitions.
+        ⚠️ `tket-json-rs` is missing OpType definitions.
         See <https://github.com/CQCL/tket-json-rs/actions/runs/${{ github.run_id }}|the failing check> for more info.
       # Rate-limit the message to once per week
       timeout-minutes: 10080


### PR DESCRIPTION
Updates the missing ops slack notifier to run daily, so we find the errors quicker.
We use the new workflow from https://github.com/CQCL/hugrverse-actions/pull/18 to add a one-week timeout, so we don't spam the chat.

The notification step was actually broken on `main`. This PR adds a `continue-on-error` flag on the test job so it doesn't get skipped the notification when it fails.