### PR TITLE
feat!: `created/discarded_qubits` circuit attribute

### DIFF
--- a/src/circuit_json.rs
+++ b/src/circuit_json.rs
@@ -206,6 +206,7 @@ pub struct ImplicitPermutation(pub Register, pub Register);
 
 /// Pytket canonical serialized circuit
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq)]
+#[non_exhaustive]
 pub struct SerialCircuit<P = String> {
     /// The name of the circuit.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -243,6 +244,22 @@ impl<P> Default for Operation<P> {
             conditional: None,
             classical: None,
             wasm: None,
+        }
+    }
+}
+
+impl<P: Default> Default for SerialCircuit<P> {
+    fn default() -> Self {
+        Self {
+            name: None,
+            phase: Default::default(),
+            commands: Default::default(),
+            qubits: Default::default(),
+            bits: Default::default(),
+            implicit_permutation: Default::default(),
+            number_of_ws: None,
+            created_qubits: None,
+            discarded_qubits: None,
         }
     }
 }
@@ -295,6 +312,21 @@ impl<P> Command<P> {
 }
 
 impl<P> SerialCircuit<P> {
+    /// Initialize a new SerialCircuit with the given name and phase.
+    pub fn new(name: Option<String>, phase: P) -> Self {
+        Self {
+            name,
+            phase,
+            commands: Vec::new(),
+            qubits: Vec::new(),
+            bits: Vec::new(),
+            implicit_permutation: Vec::new(),
+            number_of_ws: None,
+            created_qubits: None,
+            discarded_qubits: None,
+        }
+    }
+
     /// Applies a function over the parameters of the circuit.
     ///
     /// Returns a new SerialCircuit with the same data, but with a new generic

--- a/src/circuit_json.rs
+++ b/src/circuit_json.rs
@@ -223,6 +223,12 @@ pub struct SerialCircuit<P = String> {
     /// Number of wasm wires in the circuit.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub number_of_ws: Option<u64>,
+    /// A list of qubits initialized at the start of the circuit.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub created_qubits: Option<Vec<Register>>,
+    /// A list of qubits discarded at the end of the circuit.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub discarded_qubits: Option<Vec<Register>>,
 }
 
 impl<P> Default for Operation<P> {
@@ -308,6 +314,8 @@ impl<P> SerialCircuit<P> {
             bits: self.bits,
             implicit_permutation: self.implicit_permutation,
             number_of_ws: self.number_of_ws,
+            created_qubits: self.created_qubits,
+            discarded_qubits: self.discarded_qubits,
         }
     }
 }


### PR DESCRIPTION
[pytket `1.7.3`](https://tket.quantinuum.com/api-docs/changelog.html#october-2022) added `created`/`discarded_qubits` fields to the circuit serialization, but we never added them here.

BREAKING CHANGE: Made `SerialCircuit` non exhaustive.