### PR TITLE
feat!: Rename `Register` and cleanup definitions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,13 +41,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: ['1.70', stable, beta]
+        rust: ['1.75', stable, beta]
         # workaround to ignore non-stable tests when running the merge queue checks
         # see: https://github.community/t/how-to-conditionally-include-exclude-items-in-matrix-eg-based-on-branch/16853/6
         isMerge:
             - ${{ github.event_name == 'merge_group' }}
         exclude:
-          - rust: '1.70'
+          - rust: '1.75'
             isMerge: true
           - rust: beta
             isMerge: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ categories = ["compilers"]
 name = "tket_json_rs"
 
 [dependencies]
+derive_more = { workspace = true, features = ["display", "from"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 uuid = { workspace = true, features = ["serde"] }
@@ -38,6 +39,7 @@ name = "integration"
 path = "tests/lib.rs"
 
 [workspace.dependencies]
+derive_more = "1.0.0"
 itertools = "0.13.0"
 pyo3 = "0.22.2"
 pythonize = "0.22.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "tket-json-rs"
 version = "0.6.2"
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.75"
 
 readme = "README.md"
 documentation = "https://docs.rs/tket-json-rs/"

--- a/src/circuit_json.rs
+++ b/src/circuit_json.rs
@@ -4,11 +4,9 @@
 use crate::clexpr::ClExpr;
 use crate::opbox::OpBox;
 use crate::optype::OpType;
-use serde::{Deserialize, Serialize};
+use crate::register::{Bit, BitRegister, ElementId, Qubit};
 
-/// A register of locations sharing the same name.
-#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq, Hash)]
-pub struct Register(pub String, pub Vec<i64>);
+use serde::{Deserialize, Serialize};
 
 /// A gate defined by a circuit.
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq)]
@@ -19,23 +17,6 @@ pub struct CompositeGate {
     pub args: Vec<String>,
     /// The circuit defining the gate.
     pub definition: Box<SerialCircuit>,
-}
-
-/// A classical bit register.
-#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq, Hash)]
-pub struct BitRegister {
-    /// Name of the bit register.
-    pub name: String,
-    /// Number of bits in the register.
-    pub size: u32,
-}
-
-/// A vector of booleans.
-#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq, Hash)]
-#[serde(transparent)]
-pub struct Bitstring {
-    /// Vector of booleans.
-    pub vec: Vec<bool>,
 }
 
 /// A 2D matrix.
@@ -54,7 +35,7 @@ pub enum ClassicalExpUnit {
     /// Unsigned 32-bit integer.
     U32(u32),
     /// Register of locations.
-    Register(Register),
+    Bit(Bit),
     /// Register of bits.
     BitRegister(BitRegister),
     /// A nested classical expression.
@@ -195,7 +176,9 @@ pub struct Command<P = String> {
     /// The operation to be applied.
     pub op: Operation<P>,
     /// The arguments to the operation.
-    pub args: Vec<Register>,
+    ///
+    /// May correspond to either [`Qubit`]s or [`Bit`]s, depending on the operation.
+    pub args: Vec<ElementId>,
     /// Operation group identifier.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub opgroup: Option<String>,
@@ -209,7 +192,7 @@ pub struct Permutation(pub Vec<(Vec<bool>, Vec<bool>)>);
 
 /// An implicit permutation of the elements of a register.
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq, Hash)]
-pub struct ImplicitPermutation(pub Register, pub Register);
+pub struct ImplicitPermutation(pub Qubit, pub Qubit);
 
 /// Pytket canonical serialized circuit
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq)]
@@ -223,9 +206,9 @@ pub struct SerialCircuit<P = String> {
     /// List of commands in the circuit.
     pub commands: Vec<Command<P>>,
     /// Input qubit registers.
-    pub qubits: Vec<Register>,
+    pub qubits: Vec<Qubit>,
     /// Input bit registers.
-    pub bits: Vec<Register>,
+    pub bits: Vec<Bit>,
     /// Implicit permutation of the output qubits.
     pub implicit_permutation: Vec<ImplicitPermutation>,
     /// Number of wasm wires in the circuit.
@@ -233,10 +216,10 @@ pub struct SerialCircuit<P = String> {
     pub number_of_ws: Option<u64>,
     /// A list of qubits initialized at the start of the circuit.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub created_qubits: Option<Vec<Register>>,
+    pub created_qubits: Option<Vec<Qubit>>,
     /// A list of qubits discarded at the end of the circuit.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub discarded_qubits: Option<Vec<Register>>,
+    pub discarded_qubits: Option<Vec<Bit>>,
 }
 
 impl<P> Default for Operation<P> {

--- a/src/circuit_json.rs
+++ b/src/circuit_json.rs
@@ -34,7 +34,7 @@ pub struct Matrix<T = f64> {
 pub enum ClassicalExpUnit {
     /// Unsigned 32-bit integer.
     U32(u32),
-    /// Register of locations.
+    /// Individual bit.
     Bit(Bit),
     /// Register of bits.
     BitRegister(BitRegister),
@@ -205,9 +205,9 @@ pub struct SerialCircuit<P = String> {
     pub phase: P,
     /// List of commands in the circuit.
     pub commands: Vec<Command<P>>,
-    /// Input qubit registers.
+    /// Input qubits.
     pub qubits: Vec<Qubit>,
-    /// Input bit registers.
+    /// Input bits.
     pub bits: Vec<Bit>,
     /// Implicit permutation of the output qubits.
     pub implicit_permutation: Vec<ImplicitPermutation>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod opbox;
 pub mod optype;
 #[cfg(feature = "pyo3")]
 pub mod pytket;
+pub mod register;
 
 pub use circuit_json::SerialCircuit;
 pub use optype::OpType;

--- a/src/opbox.rs
+++ b/src/opbox.rs
@@ -7,9 +7,10 @@
 use std::collections::HashMap;
 
 use crate::circuit_json::{
-    Bitstring, ClassicalExp, CompositeGate, Matrix, Operation, Permutation, Register, SerialCircuit,
+    ClassicalExp, CompositeGate, Matrix, Operation, Permutation, SerialCircuit,
 };
 use crate::optype::OpType;
+use crate::register::{Bitstring, Qubit};
 use serde::{Deserialize, Serialize};
 
 /// Unique identifier for an [`OpBox`].
@@ -113,7 +114,7 @@ pub enum OpBox {
         /// Number of qubits.
         n_qubits: u32,
         /// Map from qubits to inputs.
-        qubit_indices: Vec<(Register, u32)>,
+        qubit_indices: Vec<(Qubit, u32)>,
         /// The phase polynomial definition.
         /// Represented by a map from bitstring to expression of coefficient.
         phase_polynomial: Vec<Vec<(Bitstring, String)>>,
@@ -361,7 +362,7 @@ pub struct UnitaryTableau {
     /// A symplectic tableau.
     pub tab: SymplecticTableau,
     /// Ordered naming of qubits in the tableau.
-    pub qubits: Vec<Register>,
+    pub qubits: Vec<Qubit>,
 }
 
 /// Binary matrix form of a collection of Pauli strings.

--- a/src/register.rs
+++ b/src/register.rs
@@ -1,0 +1,65 @@
+//! Basic types for quantum and classical registers.
+
+use derive_more::{Display, From};
+use serde::{Deserialize, Serialize};
+
+/// An identifier for a bit or qubit in a register.
+///
+/// See [`Qubit`] and [`Bit`] for more specific types.
+///
+/// The first element is the name of the register, and the second element is a
+/// multi-dimensional index into the register.
+#[derive(Display, Deserialize, Serialize, Clone, Debug, PartialEq, Eq, Hash)]
+#[display("{_0}[{}]", _1.iter().map(|i| i.to_string()).collect::<Vec<_>>().join(", "))]
+pub struct ElementId(pub String, pub Vec<i64>);
+
+/// An identifier for a qubit in a register.
+///
+/// See [`ElementId`] for the concrete generic index.
+#[derive(Display, Deserialize, Serialize, Clone, Debug, PartialEq, Eq, Hash, From)]
+#[display("{id}")]
+#[serde(transparent)]
+pub struct Qubit {
+    /// Identifier for the qubit.
+    pub id: ElementId,
+}
+
+/// An identifier for a bit in a [`BitRegister`].
+///
+/// See [`ElementId`] for the concrete generic index.
+#[derive(Display, Deserialize, Serialize, Clone, Debug, PartialEq, Eq, Hash, From)]
+#[display("{id}")]
+#[serde(transparent)]
+pub struct Bit {
+    /// Identifier for the bit.
+    pub id: ElementId,
+}
+
+/// A classical bit register.
+#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct BitRegister {
+    /// Name of the bit register.
+    pub name: String,
+    /// Number of bits in the register.
+    pub size: u32,
+}
+
+/// A vector of booleans.
+#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq, Hash)]
+#[serde(transparent)]
+pub struct Bitstring {
+    /// Vector of booleans.
+    pub vec: Vec<bool>,
+}
+
+impl From<Qubit> for ElementId {
+    fn from(q: Qubit) -> Self {
+        q.id
+    }
+}
+
+impl From<Bit> for ElementId {
+    fn from(b: Bit) -> Self {
+        b.id
+    }
+}


### PR DESCRIPTION
Renames `Register` to `ElementId`, and adds two wrappers `Bit` and `Qubit` to use where appropriate.
Since we are doing a breaking change, I moved the related definitions to a new file to keep things clean.

BREAKING CHANGE: `Register` renamed to `ElementId`, `Qubit` and `Bit`
BREAKING CHANGE: Moved some definitions from `::circuit_json` to `::register`
BREAKING CHANGE: Bumped MSRV to `rust 1.75`