### PR TITLE
chore: Update MSRV badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,5 +26,5 @@ This project is licensed under Apache License, Version 2.0 ([LICENSE][] or http:
   [docs]: https://img.shields.io/docsrs/tket-json-rs/latest
   [crates]: https://img.shields.io/crates/v/tket-json-rs
   [LICENSE]: LICENCE
-  [msrv]: https://img.shields.io/badge/rust-1.70.0%2B-blue.svg?maxAge=3600
+  [msrv]: https://img.shields.io/badge/rust-1.75.0%2B-blue.svg?maxAge=3600
   [CHANGELOG]: CHANGELOG.md


### PR DESCRIPTION
#89 bumped the MSRV to 1.75, but didn't update the README badge