### PR TITLE
feat!: Support old `Composite` alias for `CustomGate`

### DIFF
--- a/src/circuit_json.rs
+++ b/src/circuit_json.rs
@@ -9,8 +9,10 @@ use crate::register::{Bit, BitRegister, ElementId, Qubit};
 use serde::{Deserialize, Serialize};
 
 /// A gate defined by a circuit.
+///
+/// Previously known as `CompositeGate`.
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq)]
-pub struct CompositeGate {
+pub struct CustomGate {
     /// Name of the composite gate.
     pub name: String,
     /// Expressions corresponding to parameter values of the composite gate, if it has parameters.

--- a/src/opbox.rs
+++ b/src/opbox.rs
@@ -7,7 +7,7 @@
 use std::collections::HashMap;
 
 use crate::circuit_json::{
-    ClassicalExp, CompositeGate, Matrix, Operation, Permutation, SerialCircuit,
+    ClassicalExp, CustomGate, Matrix, Operation, Permutation, SerialCircuit,
 };
 use crate::optype::OpType;
 use crate::register::{Bitstring, Qubit};
@@ -129,10 +129,11 @@ pub enum OpBox {
     /// A user-defined assertion specified by a 2x2, 4x4, or 8x8 projector matrix.
     ProjectorAssertionBox { id: BoxID, matrix: Matrix },
     /// A user-defined gate defined by a parametrised Circuit.
+    #[serde(alias = "Composite")]
     CustomGate {
         id: BoxID,
         /// The gate defined as a circuit.
-        gate: CompositeGate,
+        gate: CustomGate,
         // Vec of Symengine Expr
         params: Vec<String>,
     },

--- a/src/optype.rs
+++ b/src/optype.rs
@@ -486,6 +486,7 @@ pub enum OpType {
     /// See [`CustomGate`]
     ///
     ///   [`CustomGate`]: crate::opbox::OpBox::CustomGate
+    #[serde(alias = "Composite")]
     CustomGate,
 
     /// See [`QControlBox`]


### PR DESCRIPTION
Closes #67 

BREAKING CHANGE: Renamed `circuit_json::CompositeGate` to `CustomGate`