### PR TITLE
ci: Make an issue when ops are missing, instead of messaging slack

### DIFF
--- a/.github/workflows/missing-ops.yml
+++ b/.github/workflows/missing-ops.yml
@@ -23,7 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     outputs:
-      should_notify: ${{ steps.check_status.outputs.result }}
+      should_notify: ${{ steps.check_missing_optypes.outputs.fail }}
+      diagnostic: ${{ steps.check_missing_optypes.outputs.diagnostic }}
     steps:
       - uses: actions/checkout@v4
       - uses: mozilla-actions/sccache-action@v0.0.6
@@ -42,31 +43,36 @@ jobs:
         run: poetry -C tests update
       - name: Run the missing op types test
         id: check_missing_optypes
-        run: poetry -C tests run -- cargo test --test integration -- --ignored missing_optypes
-      - name: Set output flags
-        id: check_status
-        if: always()
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const outcome = ${{ steps.check_missing_optypes.outcome != 'success' }};
-            console.log(`The outcome is: ${outcome}`);
-            return outcome
-          result-encoding: string
+        run: |
+          set +e
+          poetry -C tests run -- cargo test --test integration -- --ignored missing_optypes --nocapture --test-threads=1 > missing_optypes.txt
+          if [ $? -eq 0 ]; then
+            echo "The test passed."
+            echo "fail=false" >> $GITHUB_OUTPUT
+          else
+            echo "The test failed with error code $?."
+            echo
+            cat missing_optypes.txt
+            echo "fail=true" >> $GITHUB_OUTPUT
+          fi
+          echo "diagnostic=$(cat missing_optypes.txt)" >> $GITHUB_OUTPUT
 
-  notify-slack:
-    uses: CQCL/hugrverse-actions/.github/workflows/slack-notifier.yml@main
+  create-issue:
+    uses: CQCL/hugrverse-actions/.github/workflows/create-issue.yml@main
     needs: missing-optypes
     if: ${{ needs.missing-optypes.outputs.should_notify == 'true' && ( github.event_name == 'schedule' || github.event_name == 'push' ) }}
     with:
-      channel-id: 'C040CRWH9FF'
-      slack-message: |
-        ⚠️ `tket-json-rs` is missing OpType definitions.
-        See <https://github.com/CQCL/tket-json-rs/actions/runs/${{ github.run_id }}|the failing check> for more info.
-      # Rate-limit the message to once per week
-      timeout-minutes: 10080
-      # A repository variable used to store the last message timestamp.
-      timeout-variable: "MISSING_OPS_MSG_SENT"
+        title: "`tket-json-rs` is missing OpType definitions."
+        body: |
+            ⚠️ `tket-json-rs` is missing OpType definitions.
+
+            ```
+            $DIAGNOSTIC
+            ```
+
+            See [https://github.com/CQCL/tket-json-rs/actions/runs/${{ github.run_id }}](the failing check) for more info.
+        unique-label: "missing-ops"
+        other-labels: "bug"
     secrets:
-        SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         GITHUB_PAT: ${{ secrets.HUGRBOT_PAT }}
+        DIAGNOSTIC: ${{ needs.missing-optypes.outputs.diagnostic }}

--- a/tests/missing_optypes.rs
+++ b/tests/missing_optypes.rs
@@ -47,7 +47,8 @@ fn missing_optypes() -> PyResult<()> {
                 .fold(msg, |msg, s| msg + "  - " + &s + "\n");
             let msg =
                 msg + "Please add them to the `OpType` enum in `tket_json_rs/src/optype.rs`.\n";
-            panic!("{msg}");
+            println!("{msg}");
+            panic!("Found missing ops in `tket_json_rs`.");
         }
 
         Ok(())
@@ -74,7 +75,8 @@ fn missing_classical_optypes() -> PyResult<()> {
                 .fold(msg, |msg, s| msg + "  - " + &s + "\n");
             let msg =
                 msg + "Please add them to the `ClOp` enum in `tket_json_rs/src/clexpr/op.rs`.\n";
-            panic!("{msg}");
+            println!("{msg}");
+            panic!("Found missing classical ops in `tket_json_rs`.");
         }
 
         Ok(())


### PR DESCRIPTION
Requires the new `create-issue` workflow to be merged (https://github.com/CQCL/hugrverse-actions/pull/24).