### PR TITLE
ci: Call `semver_checks` from `pull_request_target`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,10 +71,3 @@ jobs:
         run: cargo test --verbose --no-default-features
       - name: Tests with all features
         run: cargo test --verbose --all-features
-
-  rs-semver-checks:
-    needs: [check]
-    if: ${{ github.event_name == 'pull_request' }}
-    uses: CQCL/hugrverse-actions/.github/workflows/rs-semver-checks.yml@main
-    secrets:
-      GITHUB_PAT: ${{ secrets.HUGRBOT_PAT }}

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -1,0 +1,13 @@
+name: Rust Semver Checks
+on:
+  pull_request_target:
+    branches:
+      - main
+
+jobs:
+  rs-semver-checks:
+    uses: CQCL/hugrverse-actions/.github/workflows/rs-semver-checks.yml@main
+    with:
+      apt-dependencies: capnproto
+    secrets:
+      GITHUB_PAT: ${{ secrets.HUGRBOT_PAT }}


### PR DESCRIPTION
Fixes errors when running the workflow for dependabot

See https://github.com/CQCL/hugr/pull/1661