### PR TITLE
fix: Support loading commands with `null` arguments

### DIFF
--- a/tket-json-rs/src/circuit_json.rs
+++ b/tket-json-rs/src/circuit_json.rs
@@ -8,7 +8,7 @@ use crate::register::{Bit, BitRegister, ElementId, Qubit};
 
 #[cfg(feature = "schemars")]
 use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
 /// A gate defined by a circuit.
 ///
@@ -191,10 +191,22 @@ pub struct Command<P = String> {
     /// The arguments to the operation.
     ///
     /// May correspond to either [`Qubit`]s or [`Bit`]s, depending on the operation.
+    #[serde(deserialize_with = "deserialize_command_args")]
     pub args: Vec<ElementId>,
     /// Operation group identifier.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub opgroup: Option<String>,
+}
+
+/// Deserialize the arguments of a command.
+///
+/// pytket sometimes emits a "null" value for commands with no arguments, so we
+/// treat "null" as equivalent to an empty list.
+fn deserialize_command_args<'de, D>(deserializer: D) -> Result<Vec<ElementId>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Ok(Option::<Vec<ElementId>>::deserialize(deserializer)?.unwrap_or_default())
 }
 
 /// A classic basis state permutation.

--- a/tket-json-rs/tests/circuit_roundtrip.rs
+++ b/tket-json-rs/tests/circuit_roundtrip.rs
@@ -1,7 +1,8 @@
 //! Roundtrip tests
 use assert_json_diff::assert_json_eq;
 use rstest::rstest;
-use serde_json::Value;
+use serde_json::{json, Value};
+use tket_json_rs::register::ElementId;
 use tket_json_rs::SerialCircuit;
 
 const SIMPLE: &str = include_str!("data/circuit/simple.json");
@@ -52,4 +53,49 @@ fn roundtrip(#[case] json: &str, #[case] num_commands: usize) {
     let reser: SerialCircuit = serde_json::from_value(reencoded_json).unwrap();
 
     assert_eq!(ser, reser);
+}
+
+/// pytket sometimes emits a "null" value for commands with no arguments, so we
+/// treat "null" as equivalent to an empty list.
+#[rstest]
+fn commands_with_no_args() {
+    let circuit_json = json!({
+        "bits": [],
+        "commands": [
+            {
+                "args": null,
+                "op": {
+                    "data": "",
+                    "signature": [],
+                    "type": "Barrier"
+                }
+            },
+            {
+                "args": [],
+                "op": {
+                    "data": "",
+                    "signature": [],
+                    "type": "Barrier"
+                }
+            },
+            {
+                "args": [["q", [0]]],
+                "op": {
+                    "type": "H"
+                }
+            }
+        ],
+        "implicit_permutation": [],
+        "phase": "0",
+        "qubits": [["q", [0]]]
+    });
+
+    let circuit: SerialCircuit = serde_json::from_value(circuit_json).unwrap();
+
+    assert!(circuit.commands[0].args.is_empty());
+    assert!(circuit.commands[1].args.is_empty());
+    assert_eq!(
+        circuit.commands[2].args,
+        vec![ElementId("q".to_string(), vec![0])]
+    );
 }


### PR DESCRIPTION
Barrier with no arguments may be an edge case, but better to parse the tket output correctly rather than error out due invalid json.

Found while tracking down bugs in https://github.com/Quantinuum/tket2/pull/1566